### PR TITLE
added user belongsTo relationship to posts

### DIFF
--- a/controllers/Posts.php
+++ b/controllers/Posts.php
@@ -223,4 +223,12 @@ class Posts extends Controller
 
         return $this->makePartial('show_stat');
     }
+
+    /**
+    * Add user_id for user relationship before save
+    */
+    public function formBeforeCreate($model)
+    {
+        $model->user_id = $this->user->id;
+    }
 }

--- a/models/Posts.php
+++ b/models/Posts.php
@@ -57,7 +57,8 @@ class Posts extends Model
         'category' => [
             'Indikator\News\Models\Categories',
             'order' => 'name'
-        ]
+        ],
+        'user' => ['Backend\Models\User']
     ];
 
     public $hasMany = [

--- a/updates/add_user_field_to_table.php
+++ b/updates/add_user_field_to_table.php
@@ -1,0 +1,23 @@
+<?php namespace Indikator\News\Updates;
+
+use October\Rain\Database\Updates\Migration;
+use Schema;
+
+class AddUserFieldToTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('indikator_news_posts', function($table)
+        {
+            $table->integer('user_id')->unsigned()->nullable()->index();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('indikator_news_posts', function($table)
+        {
+            $table->dropColumn('user_id');
+        });
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -109,3 +109,6 @@
     - adding_custom_newsletter_content_fields_to_posts.php
 1.10.5: Minor UI and code improvements.
 1.10.6: Improved the mail statistics of user.
+1.10.7:
+    - Added user relation.
+    - add_user_field_to_table.php


### PR DESCRIPTION
Signed-off-by: Fenn-25 <fenn25.fn@gmail.com>

As mentioned in #80 It's necessary for developers to be able to access the `post.user` (author) directly from the post object without any custom code. 
The relationship is implemented using the default `Backend\Models\User` model.