### PR TITLE
Memory limit

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -209,7 +209,7 @@ class Plugin extends PluginBase
     public function registerSchedule($schedule)
     {
         $memory = (int)Config::get('indikator.news::memory_limit');
-        $schedule->command('queue:work --daemon --queue=newsletter --memory-' . $memory)->everyMinute()->withoutOverlapping();
+        $schedule->command('queue:work --daemon --queue=newsletter --memory=' . $memory)->everyMinute()->withoutOverlapping();
     }
 
     public function boot()

--- a/Plugin.php
+++ b/Plugin.php
@@ -9,6 +9,7 @@ use Indikator\News\Models\Posts;
 use Indikator\News\Models\Settings;
 use Indikator\News\Controllers\Posts as PostsController;
 use Backend\Models\User;
+use Config;
 
 class Plugin extends PluginBase
 {
@@ -207,7 +208,8 @@ class Plugin extends PluginBase
 
     public function registerSchedule($schedule)
     {
-        $schedule->command('queue:work --daemon --queue=newsletter')->everyMinute()->withoutOverlapping();
+        $memory = (int)Config::get('indikator.news::memory_limit');
+        $schedule->command('queue:work --daemon --queue=newsletter --memory-' . $memory)->everyMinute()->withoutOverlapping();
     }
 
     public function boot()

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'memory_limit' => '128',
+];


### PR DESCRIPTION
Added memory limit option for queue:work command. By default its 128, which is the limit that is being used right now.