### PR TITLE
added default meta tags for seo

### DIFF
--- a/components/Post.php
+++ b/components/Post.php
@@ -66,9 +66,23 @@ class Post extends ComponentBase
             $meta_description = substr($meta_description, 0, 252).'...';
         }
 
+                // General SEO Tags
         $this->page->title = $post->title;
         $this->page->meta_title = $post->title;
         $this->page->meta_description = $meta_description;
+        $this->page->meta_canonical = $post->url;
+        $this->page->meta_image_src = $post->image;
+        // Create keyword list, from category name and tag list.
+        $post_keywords = $post->category->name.', ';
+        foreach ($post as $key => $post->tags) {
+            $post_keywords .= 'tag';
+            if($key != (count($post->tags) - 1)){
+                $post_keywords .= ', ';
+            }
+        }
+        $this->page->meta_keywords = $post_keywords;
+
+        
 
         return $post;
     }


### PR DESCRIPTION
REF : #112 

I think if we add these default tags these way, we can use them to add Facebook and Twitter Cards by default if we want?

Additionally, if someone does not activate SEO in the settings to manage it their self this should be added.

For the SEO settings itself, I think we need an issue to indicate that more meta tags are need,  including Facebook, Twitter, Canonical and Keywords! Very important for SEO and SM