### PR TITLE
fixed bug with building key_word list

### DIFF
--- a/components/Post.php
+++ b/components/Post.php
@@ -74,8 +74,8 @@ class Post extends ComponentBase
         $this->page->meta_image_src = $post->image;
         // Create keyword list, from category name and tag list.
         $post_keywords = $post->category->name.', ';
-        foreach ($post as $key => $post->tags) {
-            $post_keywords .= 'tag';
+        foreach ($post->tags as $key => $tag) {
+            $post_keywords .= $tag;
             if($key != (count($post->tags) - 1)){
                 $post_keywords .= ', ';
             }


### PR DESCRIPTION
I noticed you merged the PR (#122) for the keyword list proposition! It was a draft PR and you should quickly correct it with this.

Additionally, we would have to add a binding for the keyword list in the SEO part of the documentation, since there is some code there.

Signed-off-by: fenn-cs <fenn25.fn@gmail.com>