### PR TITLE
Fixed PostgreSQL error 42883

### DIFF
--- a/controllers/Statistics.php
+++ b/controllers/Statistics.php
@@ -162,32 +162,32 @@ class Statistics extends Controller
     protected function prepareLog()
     {
         $log['queued'] = Db::table('indikator_news_newsletter_logs')
-            ->select(Db::raw("count(id) as c, YEAR(queued_at) as y, MONTH(queued_at) as m"))
-            ->groupBy(Db::raw("YEAR(queued_at), MONTH(queued_at)"))
+            ->select(Db::raw("count(id) as c, extract(year from queued_at) as y, extract(month from queued_at) as m"))
+            ->groupBy(Db::raw("extract(year from queued_at), extract(month from queued_at)"))
             ->orderBy('y')
             ->orderBy('m')
             ->get();
 
         $log['send'] = Db::table('indikator_news_newsletter_logs')
-            ->select(Db::raw("count(id) as c, YEAR(send_at) as y, MONTH(send_at) as m"))
+            ->select(Db::raw("count(id) as c, extract(year from send_at) as y, extract(month from send_at) as m"))
             ->whereNotNull('send_at')
-            ->groupBy(Db::raw("YEAR(send_at), MONTH(send_at)"))
+            ->groupBy(Db::raw("extract(year from send_at), extract(month from send_at)"))
             ->orderBy('y')
             ->orderBy('m')
             ->get();
 
         $log['viewed'] = Db::table('indikator_news_newsletter_logs')
-            ->select(Db::raw("count(id) as c, YEAR(viewed_at) as y, MONTH(viewed_at) as m"))
+            ->select(Db::raw("count(id) as c, extract(year from viewed_at) as y, extract(month from viewed_at) as m"))
             ->whereNotNull('viewed_at')
-            ->groupBy(Db::raw("YEAR(viewed_at), MONTH(viewed_at)"))
+            ->groupBy(Db::raw("extract(year from viewed_at), extract(month from viewed_at)"))
             ->orderBy('y')
             ->orderBy('m')
             ->get();
 
         $log['clicked'] = Db::table('indikator_news_newsletter_logs')
-            ->select(Db::raw("count(id) as c, YEAR(clicked_at) as y, MONTH(clicked_at) as m"))
+            ->select(Db::raw("count(id) as c, extract(year from clicked_at) as y, extract(month from clicked_at) as m"))
             ->whereNotNull('clicked_at')
-            ->groupBy(Db::raw("YEAR(clicked_at), MONTH(clicked_at)"))
+            ->groupBy(Db::raw("extract(year from clicked_at), extract(month from clicked_at)"))
             ->orderBy('y')
             ->orderBy('m')
             ->get();


### PR DESCRIPTION
Fixing PostgreSQL error: [42883] ERROR: function year(timestamp without time zone) does not exist
SQL function EXTRACT(YEAR FROM table_column) and EXTRACT(MONTH FROM table_column) is standardized and working on MySQL database type too.