### PR TITLE
Fixed error if we use Postgres database

### DIFF
--- a/classes/SubscriberService.php
+++ b/classes/SubscriberService.php
@@ -18,7 +18,7 @@ trait SubscriberService
         // Register category
         foreach ($listOfCategoryIds as $category) {
             if (is_numeric($category) && Categories::where(['id' => $category, 'hidden' => 2])->count() == 1 && Db::table('indikator_news_relations')->where(['subscriber_id' => $subscriber->id, 'categories_id' => $category])->count() == 0) {
-                Db::table('indikator_news_relations')->insertGetId([
+                Db::table('indikator_news_relations')->insert([
                     'subscriber_id' => $subscriber->id,
                     'categories_id' => $category
                 ]);


### PR DESCRIPTION
As Laravel documantation mentioned for DB class method insertGetId:

When using PostgreSQL the insertGetId method expects the auto-incrementing column to be named id. If you would like to retrieve the ID from a different "sequence", you may pass the column name as the second parameter to the insertGetId method.

In context of code, returned ID's isn't used, we don't need it.