### PR TITLE
Nested category and multiple news category support

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -239,7 +239,7 @@ class Plugin extends PluginBase
             }
 
             if ((isset($settings->fields_category) && !$settings->fields_category) || Categories::count() == 0) {
-                $form->removeField('category');
+                $form->removeField('categories');
             }
 
             if (isset($settings->fields_tags) && !$settings->fields_tags) {
@@ -312,7 +312,7 @@ class Plugin extends PluginBase
             $settings = json_decode(Db::table('system_settings')->where('item', 'indikator_news_settings')->value('value'));
 
             if ((isset($settings->fields_category) && !$settings->fields_category) || Categories::count() == 0) {
-                $list->removeColumn('category');
+                $list->removeColumn('categories');
             }
 
             if (Subscribers::where('name', '!=', '')->count() == 0) {
@@ -330,7 +330,7 @@ class Plugin extends PluginBase
         PostsController::extendListFilterScopes(function($filter)
         {
             if (Categories::count() == 0) {
-                $filter->removeScope('category');
+                $filter->removeScope('categories');
             }
         });
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Plugin is same like put together a blog and a newsletter plugin. The main differ
 <a name="main_features"></a>
 ## Main features
 * Managing posts
-* Managing categories
+* Managing nested categories
 * Managing subscribers
 * Support the SEO
 * Support the GDPR
@@ -113,7 +113,7 @@ __For post__
 * {{ post.introductory|raw }} - Summary of post
 * {{ post.content|raw }} - Content of post
 * {{ post.published_at }} - Published date of post
-* {{ post.category }} - ID of category (0: no category selected)
+* {{ post.categories }} - Categories of post
 * {{ post.tags }} - List of tags in array
 * {{ post.seo_title }} - SEO title
 * {{ post.seo_keywords }} - SEO keywords

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,3 +7,9 @@ __1.7.2 > 1.7.3__ - Removed the Stat front-end component.
 __1.7.1 > 1.7.2__ - Changed the name of the Form front-end component.
 
 __1.4.8 > 1.5.0__ - The requirement is the [RainLab Translate](http://octobercms.com/plugin/rainlab-translate) plugin 1.2.4 or higher version!
+
+__1.11.9 > 1.12.0__ 
+- New configuration was added. If you had no categories enabled or non set, you need to disable newsletter_subscriber_categories
+- If  newsletter_subscriber_categories is enabled, only subscriber with a subscription to a category will receive Newsletter.
+- If newsletter_subscriber_categories is disabled, every subscriber will receive the Newsletter.
+

--- a/classes/NewsSender.php
+++ b/classes/NewsSender.php
@@ -120,7 +120,7 @@ class NewsSender
     {
         $activeSubscribers = Subscribers::where('status', 1);
 
-        if(Settings::get('newsletter_subscriber_categories', true)) {
+        if(Settings::get('newsletter_subscriber_categories')) {
             $categoryIds = $this->news->categories()->lists('id');
             $activeSubscribers->filterCategories($categoryIds);
         }

--- a/classes/NewsSender.php
+++ b/classes/NewsSender.php
@@ -2,6 +2,7 @@
 
 use App;
 use File;
+use Indikator\News\Models\Settings;
 use Mail;
 use Queue;
 use Log;
@@ -17,7 +18,7 @@ use Indikator\News\Models\Subscribers;
 class NewsSender
 {
     /**
-     * @var Post
+     * @var Posts
      */
     protected $news;
 
@@ -119,11 +120,13 @@ class NewsSender
     {
         $activeSubscribers = Subscribers::where('status', 1);
 
-        if ($this->news->category_id > 0) {
-            $activeSubscribers = $this->news->category->subscribers()->isSubscribed();
+        if(Settings::get('newsletter_subscriber_categories', true)) {
+            $categoryIds = $this->news->categories()->lists('id');
+            $activeSubscribers->filterCategories($categoryIds);
         }
 
         $activeSubscribers = $activeSubscribers->get();
+
         $results = true;
 
         foreach ($activeSubscribers as $receiver) {
@@ -137,7 +140,7 @@ class NewsSender
      * Prepare newsletter parameters for the template by the receiver.
      * It also replaces the content with absolute urls.
      *
-     * @param $receiver
+     * @param Subscribers $receiver
      * @return array
      */
     protected function prepareNewsletterParametersForReceiver($receiver)
@@ -173,6 +176,16 @@ class NewsSender
             $this->replacedContent = preg_replace('/<img (.+)?style="width: (.+)px;"/i', '<img $1 width="$2"', $this->replacedContent);
         }
 
+        // Categories
+        $newsCategoryIds = $this->news->categories()->lists('id');
+        $subscriberCatIds = $receiver->categories()->lists('id');
+        // intersection between news and subscriber
+        $categoryIds = $newsCategoryIds->intersect($subscriberCatIds);
+
+        $categories =
+            Categories::whereIn('id', $categoryIds)
+            ->get();
+
         // Parameters
         return [
             'name'         => isset($receiver->name) ? $receiver->name : trim($receiver->first_name.' '.$receiver->last_name),
@@ -185,7 +198,8 @@ class NewsSender
             'plaintext'    => strip_tags($this->news->introductory),
             'content'      => $this->replacedContent,
             'image'        => $this->news->image,
-            'category'     => $this->news->category
+            'category'     => $categories->first(), // keep backwards compatibility
+            'categories'   => $categories
         ];
     }
 

--- a/classes/SubscriberService.php
+++ b/classes/SubscriberService.php
@@ -18,14 +18,7 @@ trait SubscriberService
     {
         // Register category
         if (is_array($listOfCategoryIds)) {
-            foreach ($listOfCategoryIds as $categoryId) {
-                if (is_numeric($categoryId) && Categories::where(['id' => $categoryId, 'hidden' => 2])->count() == 1 && Db::table('indikator_news_relations')->where(['subscriber_id' => $subscriber->id, 'categories_id' => $categoryId])->count() == 0) {
-                    Db::table('indikator_news_relations')->insert([
-                        'subscriber_id' => $subscriber->id,
-                        'categories_id' => $categoryId
-                    ]);
-                }
-            }
+            $subscriber->categories()->sync($listOfCategoryIds);
         }
 
         if (!$subscriber->isActive()) {

--- a/classes/SubscriberService.php
+++ b/classes/SubscriberService.php
@@ -18,11 +18,11 @@ trait SubscriberService
     {
         // Register category
         if (is_array($listOfCategoryIds)) {
-            foreach ($listOfCategoryIds as $category) {
-                if (is_numeric($category) && Categories::where(['id' => $category, 'hidden' => 2])->count() == 1 && Db::table('indikator_news_relations')->where(['subscriber_id' => $subscriber->id, 'categories_id' => $category])->count() == 0) {
+            foreach ($listOfCategoryIds as $categoryId) {
+                if (is_numeric($categoryId) && Categories::where(['id' => $categoryId, 'hidden' => 2])->count() == 1 && Db::table('indikator_news_relations')->where(['subscriber_id' => $subscriber->id, 'categories_id' => $categoryId])->count() == 0) {
                     Db::table('indikator_news_relations')->insert([
                         'subscriber_id' => $subscriber->id,
-                        'categories_id' => $category
+                        'categories_id' => $categoryId
                     ]);
                 }
             }

--- a/components/Categories.php
+++ b/components/Categories.php
@@ -61,8 +61,10 @@ class Categories extends ComponentBase
 
     protected function listCategories()
     {
-        $categories = NewsCategories::isActive()->getNested();
-
+        $categories = NewsCategories::with('posts_count')->isActive()->getNested();
+        $categories = $categories->filter(function($cat) {
+            return $cat->getNestedPostCount() > 0;
+        });
         return $this->linkCategories($categories);
     }
 

--- a/components/Categories.php
+++ b/components/Categories.php
@@ -54,7 +54,7 @@ class Categories extends ComponentBase
 
     protected function listCategories()
     {
-        $categories = NewsCategories::all();
+        $categories = NewsCategories::isActive()->get();
 
         $categories->each(function($category) {
             $category->setUrl($this->categoryPage, $this->controller);

--- a/components/Post.php
+++ b/components/Post.php
@@ -76,7 +76,12 @@ class Post extends ComponentBase
         $this->page->meta_image_src = $post->image;
 
         // Create keyword list, from category name and tag list.
-        $post_keywords = isset($post->category->name) ? $post->category->name.', ' : '';
+        $post_keywords = "";
+        foreach ($post->categories as $category) {
+            if (isset($category->name)) {
+                $post_keywords .= $category->name .', ';
+            }
+        }
         foreach ($post->tags as $key => $tag) {
             $post_keywords .= $tag;
             if ($key != (count($post->tags) - 1)) {

--- a/components/Post.php
+++ b/components/Post.php
@@ -51,7 +51,7 @@ class Post extends ComponentBase
                 'type'        => 'dropdown',
                 'default'     => '',
                 'group'       => 'indikator.news::lang.settings.links'
-            ]
+            ],
         ];
     }
 
@@ -100,8 +100,6 @@ class Post extends ComponentBase
                 }
 
                 $category->translateContext($code);
-
-
                 $translations[$code] =  [
                     'code' => $code,
                     'name' => $locale,
@@ -115,8 +113,10 @@ class Post extends ComponentBase
             }
 
             $this->page['post_available_locales'] = $translations;
-            $post->translateContext($currentLocale);
-            $category->translateContext($currentLocale);
+            $post->withFallbackLocale()->translateContext($currentLocale);
+
+            if ($category)
+                $category->translateContext($currentLocale);
         }
 
         $post->categories->each(function($category) {

--- a/components/Post.php
+++ b/components/Post.php
@@ -41,7 +41,7 @@ class Post extends ComponentBase
                 'title'       => 'indikator.news::lang.settings.post_title',
                 'description' => 'indikator.news::lang.settings.post_description',
                 'type'        => 'dropdown',
-                'default'     => 'news/post',
+                'default'     => '',
                 'group'       => 'indikator.news::lang.settings.links'
             ],
             'categoryPage' => [

--- a/components/Posts.php
+++ b/components/Posts.php
@@ -170,6 +170,7 @@ class Posts extends ComponentBase
             'category' => $category
         ]);
 
+
         $posts->each(function($post) use ($category) {
 
             if (is_array($category)) {

--- a/components/Posts.php
+++ b/components/Posts.php
@@ -9,17 +9,12 @@ use Redirect;
 
 class Posts extends ComponentBase
 {
-    public $posts;
-
-    public $noPostsMessage;
-
-    public $postPage;
-
-    public $sortOrder;
-
-    public $category;
-
-    public $searchFilter;
+    public $posts,
+        $noPostsMessage,
+        $postPage,
+        $sortOrder,
+        $category,
+        $searchFilter;
 
     public function componentDetails()
     {
@@ -124,7 +119,7 @@ class Posts extends ComponentBase
     {
         $this->prepareVars();
 
-        $this->category = $this->page['category'] = $this->loadCategory();
+        $this->categories = $this->page['category'] = $this->loadCategory();
         $this->page['currentCategorySlug'] = $this->category ? $this->category->slug : null;
         $this->posts = $this->page['posts'] = $this->listPosts();
 

--- a/components/Posts.php
+++ b/components/Posts.php
@@ -170,13 +170,12 @@ class Posts extends ComponentBase
             'category' => $category
         ]);
 
-
         $posts->each(function($post) use ($category) {
 
             if (is_array($category)) {
                 $activeCategory = $post->categories->whereIn('id', $category)->first();
             } else {
-                $activeCategory = $this->category;
+                $activeCategory = $this->category ?? $post->categories->first();
             }
 
             $post->setUrl($this->postPage, $this->controller, $activeCategory);

--- a/components/Posts.php
+++ b/components/Posts.php
@@ -157,8 +157,9 @@ class Posts extends ComponentBase
         $category = $this->category ? $this->category->id : null;
 
         if ($this->nestedCategoryPosts && $this->category) {
-            $category = $this->category->getNested()->pluck('id')->all();
+            $category = $this->category->getAllChildrenAndSelf()->pluck('id')->all();
         }
+
         $posts = NewsPost::with('categories')->listFrontEnd([
             'page'     => $this->property('pageNumber'),
             'sort'     => $this->property('sortOrder'),
@@ -169,8 +170,15 @@ class Posts extends ComponentBase
             'category' => $category
         ]);
 
-        $posts->each(function($post) {
-            $post->setUrl($this->postPage, $this->controller);
+        $posts->each(function($post) use ($category) {
+
+            if (is_array($category)) {
+                $activeCategory = $post->categories->whereIn('id', $category)->first();
+            } else {
+                $activeCategory = $this->category;
+            }
+
+            $post->setUrl($this->postPage, $this->controller, $activeCategory);
             $post->categories->each(function($category) {
                 $category->setUrl($this->categoryPage, $this->controller);
             });

--- a/components/Subscribe.php
+++ b/components/Subscribe.php
@@ -24,8 +24,8 @@ class Subscribe extends ComponentBase
 
     public function onRun()
     {
-        $category = Categories::where(['status' => 1, 'hidden' => 2]);
-        $this->page['category_list']  = $category->get()->all();
+        $category = Categories::isActive();
+        $this->page['category_list']  = $category->get();
         $this->page['category_count'] = $category->count();
 
         $this->page['text_messages'] = Lang::get('indikator.news::lang.messages.subscribed');

--- a/components/Subscribe.php
+++ b/components/Subscribe.php
@@ -22,11 +22,36 @@ class Subscribe extends ComponentBase
         ];
     }
 
+
+    public function defineProperties()
+    {
+        return [
+            'categoryFilter' => [
+                'title'       => 'indikator.news::lang.settings.category_filter_title',
+                'description' => 'indikator.news::lang.settings.category_filter_description',
+                'type'        => 'dropdown',
+                'default'     => ''
+            ],
+        ];
+    }
+
+    public function getCategoryFilterOptions()
+    {
+        return Categories::listsNested('name', 'id');
+    }
+
     public function onRun()
     {
-        $category = Categories::isActive();
-        $this->page['category_list']  = $category->get();
-        $this->page['category_count'] = $category->count();
+        $categoryFilter = $this->property('categoryFilter');
+        if ($categoryFilter) {
+            $categories =  Categories::find($categoryFilter)->allChildren(false)->isActive()->get();
+            $this->page['category_list']  = $categories;
+            $this->page['category_count'] = $categories->count();
+        } else {
+            $category = Categories::isActive();
+            $this->page['category_list']  = $category->get();
+            $this->page['category_count'] = $category->count();
+        }
 
         $this->page['text_messages'] = Lang::get('indikator.news::lang.messages.subscribed');
         $this->page['text_name']     = Lang::get('indikator.news::lang.form.name');

--- a/components/categories/default.htm
+++ b/components/categories/default.htm
@@ -5,7 +5,7 @@
         <ul>
     {% endif %}
 
-    <li><a href="{{ category.slug }}">{{ category.name }}</a></li>
+    <li style="padding-left: {{ category.depth }}em;"><a href="{{ category.slug }}">{{ category.name }}</a></li>
     {% if loop.last %}
         </ul>
     {% endif %}

--- a/components/categories/default.htm
+++ b/components/categories/default.htm
@@ -4,8 +4,18 @@
     {% if loop.first %}
         <ul>
     {% endif %}
-
-    <li style="padding-left: {{ category.depth }}em;"><a href="{{ category.slug }}">{{ category.name }}</a></li>
+            <li>
+                <a href="{{ category.url }}">{{ category.name }}</a>
+                {% if category.children|length > 0 %}
+                    <ul style="margin-left: 0.5rem">
+                        {% for category in category.children %}
+                            <li>
+                                <a href="{{ category.url }}">{{ category.name }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </li>
     {% if loop.last %}
         </ul>
     {% endif %}

--- a/components/post/default.htm
+++ b/components/post/default.htm
@@ -19,8 +19,8 @@
         {% if post.content %}<div class="post-content">{{ post.content|raw }}</div>{% endif %}
     </div>
     <div class="post-nav">
-        {% if post.prev().title %}Prev: <a href="{{ 'blog'|page }}/{{ post.prev().slug }}" class="prev">{{ post.prev().title }}</a>{% endif %}
+        {% if __SELF__.prev %}Prev: <a href="{{ __SELF__.prev.url }}" class="prev">{{ __SELF__.prev.title }}</a>{% endif %}
         <br>
-        {% if post.next().title %}Next: <a href="{{ 'blog'|page }}/{{ post.next().slug }}" class="next">{{ post.next().title }}</a>{% endif %}
+        {% if __SELF__.next %}Next: <a href="{{ __SELF__.next.url }}" class="next">{{ __SELF__.next.title }}</a>{% endif %}
     </div>
 </div>

--- a/components/posts/default.htm
+++ b/components/posts/default.htm
@@ -3,9 +3,9 @@
 <div class="post-list">
     {% for post in posts %}
     <div class="post-item">
-        {% if post.image %}<div class="post-image"><a href="/{{ postPage }}/{{ post.slug }}"><img src="{{ post.image|media }}" alt="{{ post.title }}"></a></div>{% endif %}
+        {% if post.image %}<div class="post-image"><a href="{{ post.url }}"><img src="{{ post.image|media }}" alt="{{ post.title }}"></a></div>{% endif %}
 
-        <h2 class="post-title"><a href="/{{ postPage }}/{{ post.slug }}">{{ post.title }}</a></h2>
+        <h2 class="post-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
         <p class="post-date">{{ post.published_at|date('Y-m-d') }}</p>
         {% if post.tags %}
         <p class="post-tags">Tags:

--- a/controllers/Categories.php
+++ b/controllers/Categories.php
@@ -57,8 +57,7 @@ class Categories extends Controller
                 }
 
                 $item->delete();
-
-                Posts::where('category_id', $itemId)->update(['category_id' => 0]);
+                $item->posts()->detach();
                 Db::table('indikator_news_relations')->where('categories_id', $itemId)->delete();
             }
 

--- a/controllers/Categories.php
+++ b/controllers/Categories.php
@@ -13,12 +13,14 @@ class Categories extends Controller
     public $implement = [
         \Backend\Behaviors\FormController::class,
         \Backend\Behaviors\ListController::class,
-        \Backend\Behaviors\ReorderController::class
+        \Backend\Behaviors\ReorderController::class,
+        \Backend\Behaviors\RelationController::class
     ];
 
     public $formConfig = 'config_form.yaml';
     public $listConfig = 'config_list.yaml';
     public $reorderConfig = 'config_reorder.yaml';
+    public $relationConfig = 'config_relation.yaml';
 
     public $requiredPermissions = ['indikator.news.categories'];
 

--- a/controllers/Posts.php
+++ b/controllers/Posts.php
@@ -19,12 +19,14 @@ class Posts extends Controller
     public $implement = [
         \Backend\Behaviors\FormController::class,
         \Backend\Behaviors\ListController::class,
-        \Backend\Behaviors\ImportExportController::class
+        \Backend\Behaviors\ImportExportController::class,
+        \Backend\Behaviors\RelationController::class
     ];
 
     public $formConfig = 'config_form.yaml';
     public $listConfig = 'config_list.yaml';
     public $importExportConfig = 'config_import_export.yaml';
+    public $relationConfig = 'config_relation.yaml';
 
     public $requiredPermissions = ['indikator.news.posts'];
 

--- a/controllers/Subscribers.php
+++ b/controllers/Subscribers.php
@@ -124,10 +124,6 @@ class Subscribers extends Controller
         }
 
         if ($subscriber->status == 3 && $subscriber->confirmation_hash == $hash) {
-            if ($subscriber->registered_at < now()) {
-                Flash::error(Lang::get('indikator.news::lang.flash.subscriber_confirmation_token_expired'));
-                return Redirect::to('/');
-            }
 
             $subscriber->confirmed_ip = Request::ip();
             $subscriber->confirmed_at = now();

--- a/controllers/categories/_posts.htm
+++ b/controllers/categories/_posts.htm
@@ -1,0 +1,1 @@
+<?= $this->relationRender('all_posts'); ?>

--- a/controllers/categories/config_relation.yaml
+++ b/controllers/categories/config_relation.yaml
@@ -1,0 +1,11 @@
+
+all_posts:
+  label: indikator.news::lang.title.posts
+  view:
+    recordUrl: 'indikator/news/posts/update/:id'
+    list: $/indikator/news/models/posts/columns.yaml
+    toolbarButtons: add|remove
+    showSearch: true
+  manage:
+    recordsPerPage: 10
+    showSearch: true

--- a/controllers/categories/reorder.htm
+++ b/controllers/categories/reorder.htm
@@ -11,6 +11,6 @@
     }
 </style>
 
-<div style="margin-left:20px;">
+<div style="margin:20px;">
     <?= $this->reorderRender() ?>
 </div>

--- a/controllers/posts/_categories.htm
+++ b/controllers/posts/_categories.htm
@@ -1,0 +1,1 @@
+<?= $this->relationRender('all_categories'); ?>

--- a/controllers/posts/config_filter.yaml
+++ b/controllers/posts/config_filter.yaml
@@ -6,9 +6,9 @@ scopes:
 
     category:
         label: indikator.news::lang.form.category
-        conditions: category_id in (:filtered)
-        modelClass: Indikator\News\Models\Posts
-        options: filterCategory
+        modelClass: Indikator\News\Models\Categories
+        nameFrom: name
+        scope: FilterCategories
 
     statistics:
         label: indikator.news::lang.stat.viewed

--- a/controllers/posts/config_import_export.yaml
+++ b/controllers/posts/config_import_export.yaml
@@ -6,6 +6,7 @@ import:
     title: indikator.news::lang.menu.import
     modelClass: Indikator\News\Models\PostsImport
     list: $/indikator/news/models/postsimport/columns.yaml
+    form: $/indikator/news/models/postsimport/fields.yaml
     redirect: indikator/news/posts
     permissions: indikator.news.import_export
 

--- a/controllers/posts/config_relation.yaml
+++ b/controllers/posts/config_relation.yaml
@@ -1,0 +1,12 @@
+
+all_categories:
+  label: indikator.news::lang.title.categories
+  view:
+    recordUrl: 'indikator/news/categories/update/:id'
+    list: $/indikator/news/models/categories/columns.yaml
+    toolbarButtons: add|remove
+    showSearch: true
+  manage:
+    recordsPerPage: 10
+    showSearch: true
+    scope: notHidden

--- a/formwidgets/CategoryInfo.php
+++ b/formwidgets/CategoryInfo.php
@@ -23,7 +23,7 @@ class CategoryInfo extends FormWidgetBase
         $uriList  = explode('/', Request::path());
         $category = Categories::whereId(end($uriList))->first();
 
-        $this->vars['posts']       = Posts::where('category_id', $uriList[5])->count();
+        $this->vars['posts']       = Posts::inCategory($uriList[5])->count();
         $this->vars['subscribers'] = Db::table('indikator_news_relations')->where('categories_id', $category->id)->count();
         $this->vars['sort_order']  = $category->sort_order;
         $this->vars['updated_at']  = substr($category->updated_at, 0, -3);

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -59,6 +59,7 @@ return [
         'content' => 'Inhalt',
         'image' => 'Bild',
         'category' => 'Kategorie',
+        'categories' => 'Kategorien',
         'author' => 'Autor',
         'status' => 'Status',
         'status_published' => 'Veröffentlicht',

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -151,9 +151,11 @@ return [
         'email_view_tracking_comment' => 'Trackt wenn eine Person eine Email öffnet.',
         'email_view_tracking_warning' => [
             'heading' => 'Vorsicht beim verwenden von Email-Tracking' ,
-            'subheading' => 'Dies ist nicht in allen Ländern erlaubt!',
-            'text' => 'Wenn Sie diese Funktion verwenden stellen Sie bitte sicher, dass es in Ihren Land erlaubt ist. Eventuell müssen Sie Ihre Abonneten darüber informieren.'
+            'subheading' => 'Dies benötigt die Zustimmung des Abonnenten!',
+            'text' => 'Wenn Sie diese Funktion verwenden stellen Sie bitte sicher, dass sie die Datenschutzrichtlinien in Ihren Land einhalten.'
         ],
+        'newsletter_subscriber_categories' => 'Sende Newsletter an Abonnenten mit entsprechender Kategorie',
+        'newsletter_subscriber_categories_comment' => 'Wenn dies gesetzt ist erhalten alle Abonnenten einen Newsletter, wenn sie eine Kategorie von den Newsletter abonniert haben. Wenn die Option ausgeschaltet ist, erhalten alle aktiven Abonnenten ein Newsletter.',
         'newsletter_double_opt_in' => 'Newsletter Registrierung Bestätigen (Double Opt-in)',
         'newsletter_double_opt_in_comment' => 'Sendet eine Email an den neuen Abonneten, welche seine Email-Adresse betätigen muss.',
         'statistic_show_posts' => 'Zeige Einträge',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -167,6 +167,8 @@ return [
         ],
         'newsletter_double_opt_in' => 'Newsletter registration confirmation',
         'newsletter_double_opt_in_comment' => 'Sends an email to the new subscriber which has to confirm his email address',
+        'newsletter_subscriber_categories' => 'Send newsletter only to subscribers which subscribed post category',
+        'newsletter_subscriber_categories_comment' => 'If this is set, a subscriber receives a newsletter if she subscribed to one of the post categories. If this is disabled, every subscriber receives any newsletter.',
         'admin_section' => 'Settings of site administrators',
         'show_posts' => 'Show the following post on front-end as backend user:',
         'statistic_show_posts' => 'Show posts',
@@ -174,7 +176,7 @@ return [
         'statistic_show_longest_posts' => 'Show longest posts',
         'statistic_show_shortest_posts' => 'Show shortest posts',
         'statistic_comment' => 'In the Statistics page.',
-        'extra_fields' => 'Extra fields for News form'
+        'extra_fields' => 'Extra fields for News form',
     ],
     'widget' => [
         'posts' => 'News - Posts',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -61,6 +61,7 @@ return [
         'content' => 'Content',
         'image' => 'Image',
         'category' => 'Category',
+        'categories' => 'Categories',
         'tags' => 'Tags',
         'author' => 'Author',
         'select_user' => '-- select user --',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -230,10 +230,14 @@ return [
         'list_notfeatured' => 'Not featured',
         'translated_title' => 'Show only translated posts',
         'translated_description' => 'Hide the post, if the language of current post is not equal the website language.',
+        'category_slug_title' => 'Category slug',
+        'category_slug_description' => 'Look up the category using the supplied slug value. This property is used by the default component partial for marking the currently active category.',
         'category_page_title' => 'Category page',
         'category_page_description' => 'Name of the category page file for the category links. This property is used by the default component partial.',
         'category_filter_title' => 'Category filter',
         'category_filter_description' => 'Enter a category slug or URL parameter to filter the posts by. Leave empty to show all posts.',
+        'nested_category_posts_title' => 'Nested Posts',
+        'nested_category_posts_description' => 'Display posts which are in a nested category.',
         'links' => 'Links'
     ],
     'sorting' => [

--- a/lang/hu/lang.php
+++ b/lang/hu/lang.php
@@ -61,6 +61,7 @@ return [
         'content' => 'Tartalom',
         'image' => 'Kép',
         'category' => 'Kategória',
+        'categories' => 'Kategóriák',
         'tags' => 'Címkék',
         'author' => 'Szerző',
         'select_user' => '-- válasszon felhasználót --',

--- a/lang/pl/lang.php
+++ b/lang/pl/lang.php
@@ -59,6 +59,7 @@ return [
         'content' => 'Treść',
         'image' => 'Obrazek',
         'category' => 'Kategoria',
+        'categories' => 'Kategorie',
         'author' => 'Autor',
         'status' => 'Status',
         'status_published' => 'Opublikowany',

--- a/lang/pt-br/lang.php
+++ b/lang/pt-br/lang.php
@@ -59,6 +59,7 @@ return [
         'content' => 'Conteúdo',
         'image' => 'Imagem',
         'category' => 'Categoria',
+        'categories' => 'Categorias',
         'author' => 'Autor',
         'status' => 'Status',
         'status_published' => 'Publicado',

--- a/lang/ru/lang.php
+++ b/lang/ru/lang.php
@@ -59,6 +59,7 @@ return [
         'content' => 'Содержимое',
         'image' => 'Изображение',
         'category' => 'Категория',
+        'categories' => 'Категории',
         'author' => 'Aвтор',
         'status' => 'Статус',
         'status_published' => 'Опубликовано',

--- a/lang/zh-tw/lang.php
+++ b/lang/zh-tw/lang.php
@@ -61,6 +61,7 @@ return [
         'content' => '內容',
         'image' => '顯示圖片',
         'category' => '分類',
+        'categories' => '分類',
         'tags' => '標籤',
         'author' => '作者',
         'select_user' => '-- 選取使用者 --',

--- a/models/Categories.php
+++ b/models/Categories.php
@@ -79,6 +79,10 @@ class Categories extends Model
         return $this->url = $controller->pageUrl($pageName, $params);
     }
 
+    public function scopeNotHidden($query) {
+        $query->where('hidden', 2);
+    }
+
     public function scopeIsActive($query) {
         $query->where('hidden', 2)
             ->where('status', 1);

--- a/models/Categories.php
+++ b/models/Categories.php
@@ -32,6 +32,13 @@ class Categories extends Model
             'otherKey' => 'subscriber_id',
             'order'    => 'name'
         ],
+        'subscribers_count' => [
+            'Indikator\News\Models\Subscribers',
+            'table'    => 'indikator_news_relations',
+            'key'      => 'categories_id',
+            'otherKey' => 'subscriber_id',
+            'count' => true
+        ],
         'posts' => [
             'Indikator\News\Models\Posts',
             'table' => 'indikator_news_posts_categories',
@@ -47,13 +54,6 @@ class Categories extends Model
             'key'      => 'category_id',
             'otherKey' => 'post_id',
             'count' => true
-        ]
-    ];
-
-    public $hasMany = [
-        'posts' => [
-            'Indikator\News\Models\Posts',
-            'key' => 'category_id'
         ]
     ];
 
@@ -82,5 +82,37 @@ class Categories extends Model
     public function scopeIsActive($query) {
         $query->where('hidden', 2)
             ->where('status', 1);
+    }
+
+    public function getPostCountAttribute()
+    {
+        return optional($this->posts_count->first())->count ?? 0;
+    }
+
+    /**
+     * Count posts in this and nested categories
+     * @return int
+     */
+    public function getNestedPostCount()
+    {
+        return $this->post_count + $this->children->sum(function ($category) {
+                return $category->getNestedPostCount();
+            });
+    }
+
+    public function getSubscriberCountAttribute()
+    {
+        return optional($this->subscribers_count->first())->count ?? 0;
+    }
+
+    /**
+     * Count subscribers in this and nested categories
+     * @return int
+     */
+    public function getNestedSubscriberCount()
+    {
+        return $this->subscriber_counts + $this->children->sum(function ($category) {
+                return $category->getNestedSubscriberCount();
+            });
     }
 }

--- a/models/Categories.php
+++ b/models/Categories.php
@@ -5,7 +5,7 @@ use Model;
 class Categories extends Model
 {
     use \October\Rain\Database\Traits\Sluggable;
-    use \October\Rain\Database\Traits\Sortable;
+    use \October\Rain\Database\Traits\NestedTree;
     use \October\Rain\Database\Traits\Validation;
 
     public $implement = ['@RainLab.Translate.Behaviors.TranslatableModel'];
@@ -23,6 +23,7 @@ class Categories extends Model
         'slug' => 'name'
     ];
 
+
     public $belongsToMany = [
         'subscribers' => [
             'Indikator\News\Models\Subscribers',
@@ -30,6 +31,22 @@ class Categories extends Model
             'key'      => 'categories_id',
             'otherKey' => 'subscriber_id',
             'order'    => 'name'
+        ],
+        'posts' => [
+            'Indikator\News\Models\Posts',
+            'table' => 'indikator_news_posts_categories',
+            'order' => 'published_at desc',
+            'scope' => 'isPublished',
+            'key'      => 'category_id',
+            'otherKey' => 'post_id'
+        ],
+        'posts_count' => [
+            'Indikator\News\Models\Posts',
+            'table' => 'indikator_news_posts_categories',
+            'scope' => 'isPublished',
+            'key'      => 'category_id',
+            'otherKey' => 'post_id',
+            'count' => true
         ]
     ];
 
@@ -60,5 +77,10 @@ class Categories extends Model
         ];
 
         return $this->url = $controller->pageUrl($pageName, $params);
+    }
+
+    public function scopeIsActive($query) {
+        $query->where('hidden', 2)
+            ->where('status', 1);
     }
 }

--- a/models/Categories.php
+++ b/models/Categories.php
@@ -54,7 +54,14 @@ class Categories extends Model
             'key'      => 'category_id',
             'otherKey' => 'post_id',
             'count' => true
-        ]
+        ],
+        'all_posts' => [
+            'Indikator\News\Models\Posts',
+            'table' => 'indikator_news_posts_categories',
+            'order' => 'published_at desc',
+            'key'      => 'category_id',
+            'otherKey' => 'post_id'
+        ],
     ];
 
     public $translatable = [

--- a/models/Posts.php
+++ b/models/Posts.php
@@ -103,7 +103,7 @@ class Posts extends Model
         'categories' => [
             'Indikator\News\Models\Categories',
             'table' => 'indikator_news_posts_categories',
-            'scope' => 'IsActive',
+            'scope' => 'notHidden',
             'key'      => 'post_id',
             'otherKey' => 'category_id',
             'order' => 'name'

--- a/models/Posts.php
+++ b/models/Posts.php
@@ -103,7 +103,14 @@ class Posts extends Model
         'categories' => [
             'Indikator\News\Models\Categories',
             'table' => 'indikator_news_posts_categories',
-            'scope' => 'notHidden',
+            'scope' => 'IsActive',
+            'key'      => 'post_id',
+            'otherKey' => 'category_id',
+            'order' => 'name'
+        ],
+        'all_categories' => [
+            'Indikator\News\Models\Categories',
+            'table' => 'indikator_news_posts_categories',
             'key'      => 'post_id',
             'otherKey' => 'category_id',
             'order' => 'name'

--- a/models/Posts.php
+++ b/models/Posts.php
@@ -473,15 +473,15 @@ class Posts extends Model
      * @param string $pageName
      * @param Cms\Classes\Controller $controller
      */
-    public function setUrl($pageName, $controller)
+    public function setUrl($pageName, $controller, $category = null)
     {
         $params = [
             'id'   => $this->id,
             'slug' => $this->slug
         ];
 
-        if (array_key_exists('category', $this->getRelations())) {
-            $params['category'] = $this->category->count() ? $this->category->first()->slug : null;
+        if ($category) {
+            $params['category'] =$category->slug;
         }
 
         // Expose published year, month and day as URL parameters

--- a/models/Posts.php
+++ b/models/Posts.php
@@ -174,7 +174,11 @@ class Posts extends Model
 
     public function scopeInCategory($query, $categoryId) {
         $query->whereHas('categories', function($query) use ($categoryId) {
-            $query->whereId($categoryId);
+            if (is_array($categoryId)) {
+                $query->whereIn('id', $categoryId);
+            } else {
+                $query->whereId($categoryId);
+            }
         });
     }
     // Next and previous post
@@ -285,8 +289,8 @@ class Posts extends Model
          * Category filter
          */
         if ($category !== null) {
-            $category = NewsCategories::find($category);
-            $query->inCategory($category->id);
+
+            $query->inCategory($category);
         }
 
         $search = trim($search);

--- a/models/Posts.php
+++ b/models/Posts.php
@@ -7,6 +7,7 @@ use Cms\Classes\Page as CmsPage;
 use Indikator\News\Models\Categories as NewsCategories;
 use Db;
 use App;
+use October\Rain\Database\NestedTreeScope;
 use Str;
 use Url;
 
@@ -58,10 +59,6 @@ class Posts extends Model
     ];
 
     public $belongsTo = [
-        'category' => [
-            'Indikator\News\Models\Categories',
-            'order' => 'name'
-        ],
         'user' => ['Backend\Models\User']
     ];
 
@@ -100,6 +97,17 @@ class Posts extends Model
             'scope' => 'isFailed',
             'count' => true
         ]
+    ];
+
+    public $belongsToMany = [
+        'categories' => [
+            'Indikator\News\Models\Categories',
+            'table' => 'indikator_news_posts_categories',
+            'scope' => 'IsActive',
+            'key'      => 'post_id',
+            'otherKey' => 'category_id',
+            'order' => 'name'
+        ],
     ];
 
     public $preview = null;
@@ -145,10 +153,6 @@ class Posts extends Model
             $this->slug = Str::slug($this->title);
         }
 
-        if (!isset($this->category_id) || empty($this->category_id)) {
-            $this->category_id = 0;
-        }
-
         if (!isset($this->user_id) || empty($this->user_id)) {
             $this->user_id = 0;
         }
@@ -168,6 +172,11 @@ class Posts extends Model
         }
     }
 
+    public function scopeInCategory($query, $categoryId) {
+        $query->whereHas('categories', function($query) use ($categoryId) {
+            $query->whereId($categoryId);
+        });
+    }
     // Next and previous post
 
     /**
@@ -178,6 +187,7 @@ class Posts extends Model
      */
     public function scopeApplySibling($query, $options = [])
     {
+        // Backwards compatibility
         if (!is_array($options)) {
             $options = ['direction' => $options];
         }
@@ -191,30 +201,38 @@ class Posts extends Model
         $directionOrder = $isPrevious ? 'desc' : 'asc';
         $directionOperator = $isPrevious ? '<' : '>';
 
-        return $query
-        ->where('id', '<>', $this->id)
-        ->where($attribute, $directionOperator, $this->$attribute)
-        ->orderBy($attribute, $directionOrder);
+        $query
+            ->where('id', '<>', $this->id)
+            ->where($attribute, $directionOperator, $this->$attribute)
+            ->orderBy($attribute, $directionOrder);
+
+        if ($categoryId !== null) {
+            $query->inCategory($categoryId);
+        }
+
+        return $query;
     }
 
     /**
      * Returns the next post, if available.
      *
+     * @param int $categoryId returns the next post in this category.
      * @return self
      */
-    public function next()
+    public function next($categoryId = null)
     {
-        return self::isPublished()->applySibling()->first();
+        return self::isPublished()->applySibling(['categoryId' => $categoryId])->first();
     }
 
     /**
      * Returns the previous post, if available.
      *
+     * @param int $categoryId returns the previous post in this category.
      * @return self
      */
-    public function prev()
+    public function prev($categoryId = null)
     {
-        return self::isPublished()->applySibling(-1)->first();
+        return self::isPublished()->applySibling(['categoryId' => $categoryId, 'direction' => 'previous'])->first();
     }
 
     public function scopeListFrontEnd($query, $options)
@@ -268,9 +286,7 @@ class Posts extends Model
          */
         if ($category !== null) {
             $category = NewsCategories::find($category);
-            $query->whereHas('category', function($q) use ($category) {
-                $q->whereId($category->id);
-            });
+            $query->inCategory($category->id);
         }
 
         $search = trim($search);
@@ -311,6 +327,19 @@ class Posts extends Model
         ;
     }
 
+    /**
+     * Allows filtering for specifc categories.
+     * @param  \Illuminate\Database\Query\Builder  $query      QueryBuilder
+     * @param  array                     $categories List of category ids
+     * @return \Illuminate\Database\Query\Builder              QueryBuilder
+     */
+    public function scopeFilterCategories($query, $categories)
+    {
+        return $query->whereHas('categories', function($q) use ($categories) {
+            $q->withoutGlobalScope(NestedTreeScope::class)->whereIn('id', $categories);
+        });
+    }
+
     public function scopeIsFeatured($query, $value = 1)
     {
         return $query->where('featured', $value);
@@ -325,7 +354,6 @@ class Posts extends Model
         $clone->introductory = $post->introductory;
         $clone->content = $post->content;
         $clone->image = $post->image;
-        $clone->category_id = $post->category_id;
         $clone->featured = $post->featured;
         $clone->enable_newsletter_content = $post->enable_newsletter_content;
         $clone->newsletter_content = $post->newsletter_content;
@@ -334,9 +362,9 @@ class Posts extends Model
         $clone->seo_title = $post->seo_title;
         $clone->seo_keywords = $post->seo_keywords;
         $clone->seo_image = $post->seo_image;
-
         $clone->save();
 
+        $clone->categories()->attach($post->categories()->pluck('id')->all());
         \Event::fire('indikator.news.posts.duplicate', [&$clone, $post]);
 
         return $clone;
@@ -462,34 +490,4 @@ class Posts extends Model
         return $this->url = $controller->pageUrl($pageName, $params);
     }
 
-    private $_category = null;
-
-    public function getCategory()
-    {
-        if ($this->_category === null) {
-            $category = Categories::whereId($this->category_id)->first();
-
-            if ($category->status == 1) {
-                $this->_category = [
-                    'id'      => $category->id,
-                    'name'    => $category->name,
-                    'slug'    => $category->slug,
-                    'content' => $category->content,
-                    'image'   => $category->image
-                ];
-            }
-
-            else {
-                $this->_category = [
-                    'id'      => 0,
-                    'name'    => '',
-                    'slug'    => '',
-                    'content' => '',
-                    'image'   => ''
-                ];
-            }
-        }
-
-        return $this->_category;
-    }
 }

--- a/models/PostsExport.php
+++ b/models/PostsExport.php
@@ -6,8 +6,43 @@ class PostsExport extends ExportModel
 {
     public $table = 'indikator_news_posts';
 
+    public $belongsToMany = [
+        'post_categories' => [
+            'Indikator\News\Models\Categories',
+            'table' => 'indikator_news_posts_categories',
+            'key'      => 'post_id',
+            'otherKey' => 'category_id',
+            'order' => 'name'
+        ],
+    ];
+
+    /**
+     * The accessors to append to the model's array form.
+     * @var array
+     */
+    protected $appends = [
+        'categories',
+    ];
+
     public function exportData($columns, $sessionKey = null)
     {
-        return self::make()->get()->toArray();
+        $result = self::make()
+            ->with([
+                'post_categories'
+            ])
+            ->get()
+            ->toArray()
+        ;
+
+        return $result;
+    }
+
+    public function getCategoriesAttribute()
+    {
+        if (!$this->post_categories) {
+            return '';
+        }
+
+        return $this->encodeArrayValue($this->post_categories->lists('slug'));
     }
 }

--- a/models/SubscribersImport.php
+++ b/models/SubscribersImport.php
@@ -12,6 +12,8 @@ class SubscribersImport extends ImportModel
         'email' => 'required|email'
     ];
 
+
+
     public function importData($results, $sessionKey = null)
     {
         foreach ($results as $row => $data) {

--- a/models/categories/_posts.htm
+++ b/models/categories/_posts.htm
@@ -1,3 +1,0 @@
-<?php
-
-echo Db::table('indikator_news_posts')->where('category_id', $record->id)->count();

--- a/models/categories/columns.yaml
+++ b/models/categories/columns.yaml
@@ -25,11 +25,6 @@ columns:
         searchable: true
         invisible: true
 
-    sort_order:
-        label: indikator.news::lang.button.reorder
-        invisible: true
-        align: center
-
     posts:
         label: indikator.news::lang.menu.posts
         sortable: false

--- a/models/categories/columns.yaml
+++ b/models/categories/columns.yaml
@@ -25,10 +25,14 @@ columns:
         searchable: true
         invisible: true
 
-    post_count:
+    all_post_count:
         label: indikator.news::lang.menu.posts
+        relation: all_posts
+        relationCount: true
+        type: number
         sortable: false
         align: center
+        invisble: false
 
     subscriber_count:
         label: indikator.news::lang.menu.subscribers

--- a/models/categories/columns.yaml
+++ b/models/categories/columns.yaml
@@ -25,18 +25,14 @@ columns:
         searchable: true
         invisible: true
 
-    posts:
+    post_count:
         label: indikator.news::lang.menu.posts
         sortable: false
-        type: partial
-        path: ~/plugins/indikator/news/models/categories/_posts.htm
         align: center
 
-    subscribers:
+    subscriber_count:
         label: indikator.news::lang.menu.subscribers
         sortable: false
-        type: partial
-        path: ~/plugins/indikator/news/models/categories/_subscribers.htm
         align: center
 
     hidden:

--- a/models/categories/fields.yaml
+++ b/models/categories/fields.yaml
@@ -26,6 +26,13 @@ fields:
         span: storm
         cssClass: col-xs-12
 
+    posts:
+        label: indikator.news::lang.title.posts
+        type: partial
+        path: '$/indikator/news/controllers/categories/_posts.htm'
+        span: storm
+        cssClass: col-xs-12
+
 secondaryTabs:
 
     fields:

--- a/models/posts/_categories.htm
+++ b/models/posts/_categories.htm
@@ -1,0 +1,4 @@
+<?php
+
+echo str_limit($record->categories->pluck('name')->join(', '), 30);
+

--- a/models/posts/_category.htm
+++ b/models/posts/_category.htm
@@ -1,5 +1,0 @@
-<?php
-
-if ($record->category_id > 0) {
-    echo \Indikator\News\Models\Categories::whereId($record->category_id)->value('name');
-}

--- a/models/posts/columns.yaml
+++ b/models/posts/columns.yaml
@@ -25,11 +25,11 @@ columns:
         searchable: true
         invisible: true
 
-    category:
-        label: indikator.news::lang.form.category
+    categories:
+        label: indikator.news::lang.form.categories
         sortable: false
         type: partial
-        path: ~/plugins/indikator/news/models/posts/_category.htm
+        path: ~/plugins/indikator/news/models/posts/_categories.htm
 
     tags:
         label: indikator.news::lang.form.tags

--- a/models/posts/fields.yaml
+++ b/models/posts/fields.yaml
@@ -34,6 +34,7 @@ tabs:
         indikator.news::lang.form.content: icon-file-text-o
         indikator.news::lang.form.newsletter_content_tab: icon-envelope-o
         indikator.news::lang.form.seo_tab: icon-search
+        indikator.news::lang.form.categories: icon-tags
 
     fields:
         introductory:
@@ -99,6 +100,14 @@ tabs:
             span: storm
             cssClass: col-md-6
 
+
+        categories:
+            type: partial
+            path: '$/indikator/news/controllers/posts/_categories.htm'
+            span: storm
+            cssClass: col-xs-12
+            tab: indikator.news::lang.form.categories
+
 secondaryTabs:
 
     fields:
@@ -160,9 +169,3 @@ secondaryTabs:
             default: 2
             span: storm
             cssClass: col-xs-6
-
-        categories:
-            label: indikator.news::lang.form.categories
-            type: relation
-            span: storm
-            cssClass: col-xs-12

--- a/models/posts/fields.yaml
+++ b/models/posts/fields.yaml
@@ -19,11 +19,6 @@ fields:
         span: storm
         cssClass: col-lg-6
 
-    category:
-        label: indikator.news::lang.form.category
-        type: relation
-        span: storm
-        cssClass: col-md-6
 
     tags:
         label: indikator.news::lang.form.tags
@@ -41,7 +36,6 @@ tabs:
         indikator.news::lang.form.seo_tab: icon-search
 
     fields:
-
         introductory:
             tab: indikator.news::lang.form.introductory
             type: richeditor
@@ -55,6 +49,8 @@ tabs:
             size: giant
             span: storm
             cssClass: col-xs-12
+
+
 
         enable_newsletter_content:
             tab: indikator.news::lang.form.newsletter_content_tab
@@ -164,3 +160,9 @@ secondaryTabs:
             default: 2
             span: storm
             cssClass: col-xs-6
+
+        categories:
+            label: indikator.news::lang.form.categories
+            type: relation
+            span: storm
+            cssClass: col-xs-12

--- a/models/postsexport/columns.yaml
+++ b/models/postsexport/columns.yaml
@@ -10,7 +10,7 @@ columns:
     introductory: indikator.news::lang.form.introductory
     content: indikator.news::lang.form.content
     image: indikator.news::lang.form.image
-    category_id: indikator.news::lang.form.category
+    categories: indikator.news::lang.form.categories
     statistics: indikator.news::lang.stat.view
     status: indikator.news::lang.form.status
     featured: indikator.news::lang.form.featured

--- a/models/postsimport/columns.yaml
+++ b/models/postsimport/columns.yaml
@@ -10,7 +10,7 @@ columns:
     introductory: indikator.news::lang.form.introductory
     content: indikator.news::lang.form.content
     image: indikator.news::lang.form.image
-    category_id: indikator.news::lang.form.category
+    categories: indikator.news::lang.form.categories
     statistics: indikator.news::lang.stat.view
     status: indikator.news::lang.form.status
     featured: indikator.news::lang.form.featured

--- a/models/postsimport/fields.yaml
+++ b/models/postsimport/fields.yaml
@@ -1,0 +1,33 @@
+fields:
+
+    update_existing:
+        label: indikator.news::lang.import.update_existing_label
+        comment: indikator.news::lang.import.update_existing_comment
+        type: checkbox
+        default: true
+        span: left
+
+    auto_create_categories:
+        label: indikator.news::lang.import.auto_create_categories_label
+        comment: indikator.news::lang.import.auto_create_categories_comment
+        type: checkbox
+        default: true
+        span: right
+
+    categories:
+        label: indikator.news::lang.import.categories_label
+        commentAbove: indikator.news::lang.import.categories_comment
+        type: checkboxlist
+        span: right
+        cssClass: field-indent
+        trigger:
+            action: hide
+            field: auto_create_categories
+            condition: checked
+
+    default_author:
+        label: indikator.news::lang.import.default_author_label
+        comment: indikator.news::lang.import.default_author_comment
+        type: dropdown
+        placeholder: indikator.news::lang.import.default_author_placeholder
+        span: left

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -34,6 +34,17 @@ fields:
         default: true
         span: left
 
+    newsletter_subscriber_categories:
+        label: indikator.news::lang.backend_settings.newsletter_subscriber_categories
+        comment: indikator.news::lang.backend_settings.newsletter_subscriber_categories_comment
+        type: switch
+        default: true
+        span: left
+        trigger:
+            action: empty
+            field: fields_category
+            condition: unchecked
+
     admin_section:
         label: indikator.news::lang.backend_settings.admin_section
         type: section

--- a/updates/add_nested_categories_support.php
+++ b/updates/add_nested_categories_support.php
@@ -1,0 +1,61 @@
+<?php namespace Indikator\News\Updates;
+
+use Indikator\News\Models\Categories;
+use October\Rain\Database\Updates\Migration;
+use Schema;
+
+class AddNestedCategoriesSupport extends Migration
+{
+    public function up()
+    {
+        Schema::table('indikator_news_categories', function ($table) {
+            $table->integer('parent_id')->unsigned()->index()->nullable()->after('status');
+            $table->integer('nest_left')->unsigned()->index()->nullable()->after('parent_id');
+            $table->integer('nest_right')->unsigned()->index()->nullable()->after('nest_left');
+            $table->integer('nest_depth')->unsigned()->index()->nullable()->after('nest_right');
+        });
+
+        // use orderby instead of sorting trait, since it is not available anymore
+        $categories = (new Categories)->newQueryWithoutScopes()
+            ->orderBy('sort_order')
+            ->get();
+
+        for($i = 0; $i < count($categories); $i++) {
+            $category = $categories[$i];
+
+            $category->parent_id = null;
+            $category->nest_depth = 0;
+            $category->nest_left = $i * 2 + 1;
+            $category->nest_right = $i * 2 + 2;
+            $category->save();
+        }
+
+        Schema::table('indikator_news_categories', function ($table) {
+            $table->dropColumn('sort_order');
+        });
+
+    }
+
+    public function down()
+    {
+        if (!Schema::hasColumn('indikator_news_categories', 'sort_order')) {
+            Schema::table('indikator_news_categories', function ($table) {
+                $table->integer('sort_order')->default(1)->index()->after('status');
+            });
+        }
+
+        // keep previous order
+        $categories = Categories::all();
+        foreach ($categories as $index => $category) {
+            $category->sort_order = $index + 1;
+            $category->save();
+        }
+
+        // Drop nested columns
+        Schema::table('indikator_news_categories', function ($table) {
+            $table->dropColumn([
+                'parent_id', 'nest_left', 'nest_right', 'nest_depth'
+            ]);
+        });
+    }
+}

--- a/updates/add_nested_categories_support.php
+++ b/updates/add_nested_categories_support.php
@@ -8,12 +8,14 @@ class AddNestedCategoriesSupport extends Migration
 {
     public function up()
     {
-        Schema::table('indikator_news_categories', function ($table) {
-            $table->integer('parent_id')->unsigned()->index()->nullable()->after('status');
-            $table->integer('nest_left')->unsigned()->index()->nullable()->after('parent_id');
-            $table->integer('nest_right')->unsigned()->index()->nullable()->after('nest_left');
-            $table->integer('nest_depth')->unsigned()->index()->nullable()->after('nest_right');
-        });
+        if (!Schema::hasColumn('indikator_news_categories', 'parent_id')) {
+            Schema::table('indikator_news_categories', function ($table) {
+                $table->integer('parent_id')->unsigned()->index()->nullable()->after('status');
+                $table->integer('nest_left')->unsigned()->index()->nullable()->after('parent_id');
+                $table->integer('nest_right')->unsigned()->index()->nullable()->after('nest_left');
+                $table->integer('nest_depth')->unsigned()->index()->nullable()->after('nest_right');
+            });
+        }
 
         // use orderby instead of sorting trait, since it is not available anymore
         $categories = (new Categories)->newQueryWithoutScopes()

--- a/updates/create_categories_table.php
+++ b/updates/create_categories_table.php
@@ -9,7 +9,7 @@ class CreateCategoriesTable extends Migration
     {
         Schema::create('indikator_news_categories', function($table)
         {
-            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->string('name', 100);
             $table->string('slug', 100);
@@ -23,7 +23,7 @@ class CreateCategoriesTable extends Migration
 
         Schema::create('indikator_news_relations', function($table)
         {
-            $table->engine = 'InnoDB';
+            
             $table->integer('subscriber_id')->unsigned();
             $table->integer('categories_id')->unsigned();
             $table->primary(['subscriber_id', 'categories_id']);

--- a/updates/create_logs_table.php
+++ b/updates/create_logs_table.php
@@ -9,7 +9,7 @@ class CreateLogsTable extends Migration
     {
         Schema::create('indikator_news_newsletter_logs', function($table)
         {
-            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->integer('news_id')->nullable()->unsigned();
             $table->integer('subscriber_id')->nullable()->unsigned();

--- a/updates/create_posts_categories_table.php
+++ b/updates/create_posts_categories_table.php
@@ -1,5 +1,6 @@
 <?php namespace Indikator\News\Updates;
 
+use Indikator\News\Models\Posts;
 use October\Rain\Database\Updates\Migration;
 use Schema;
 
@@ -14,10 +15,39 @@ class CreatePostsCategoriesTable extends Migration
             $table->integer('category_id')->unsigned();
             $table->primary(['post_id', 'category_id']);
         });
+
+        $posts = (new Posts)->newQueryWithoutScopes()
+            ->get();
+
+        foreach ($posts as $post) {
+            if ($post->category_id > 0) {
+                $post->categories()->attach($post->category_id);
+            }
+        }
+
+        Schema::table('indikator_news_posts', function ($table) {
+            $table->dropColumn('category_id');
+        });
     }
 
     public function down()
     {
+        if (!Schema::hasColumn('indikator_news_posts', 'category_id')) {
+            Schema::table('indikator_news_posts', function ($table) {
+                $table->integer('category_id')->nullable()->after('last_send_at');
+            });
+        }
+
+        $posts = (new Posts)->newQueryWithoutScopes()
+            ->get();
+
+        foreach ($posts as $post) {
+            if ($cat = $post->categories->first()) {
+                $post->category_id = $cat->id;
+                $post->save();
+            }
+        }
+
         Schema::dropIfExists('indikator_news_posts_categories');
     }
 }

--- a/updates/create_posts_categories_table.php
+++ b/updates/create_posts_categories_table.php
@@ -1,0 +1,23 @@
+<?php namespace Indikator\News\Updates;
+
+use October\Rain\Database\Updates\Migration;
+use Schema;
+
+class CreatePostsCategoriesTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('indikator_news_posts_categories', function($table)
+        {
+            $table->engine = 'InnoDB';
+            $table->integer('post_id')->unsigned();
+            $table->integer('category_id')->unsigned();
+            $table->primary(['post_id', 'category_id']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('indikator_news_posts_categories');
+    }
+}

--- a/updates/create_posts_categories_table.php
+++ b/updates/create_posts_categories_table.php
@@ -10,7 +10,7 @@ class CreatePostsCategoriesTable extends Migration
     {
         Schema::create('indikator_news_posts_categories', function($table)
         {
-            $table->engine = 'InnoDB';
+            
             $table->integer('post_id')->unsigned();
             $table->integer('category_id')->unsigned();
             $table->primary(['post_id', 'category_id']);

--- a/updates/create_posts_table.php
+++ b/updates/create_posts_table.php
@@ -9,7 +9,7 @@ class CreatePostsTable extends Migration
     {
         Schema::create('news_posts', function($table)
         {
-            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->string('title', 100);
             $table->string('slug', 100);

--- a/updates/create_subscribers_table.php
+++ b/updates/create_subscribers_table.php
@@ -9,7 +9,7 @@ class CreateSubscribersTable extends Migration
     {
         Schema::create('news_subscribers', function($table)
         {
-            $table->engine = 'InnoDB';
+            
             $table->increments('id');
             $table->string('name', 100);
             $table->string('email', 100);

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -137,5 +137,7 @@
     - !!! New configuration was added. If you had no categories enabled or non set, you need to disable newsletter_subscriber_categories
     - Adding nested categories support and multiple category news.
     - If no category is set, and newsletter_subscriber_categories is enabled, none of your subscriber will receive any newsletter anymore.
+    - Added prev/next post in category
     - add_nested_categories_support.php
     - create_posts_categories_table.php
+    - set_settings_newsletter_subscriber_categories.php

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -140,4 +140,3 @@
     - Added prev/next post in category
     - add_nested_categories_support.php
     - create_posts_categories_table.php
-    - set_settings_newsletter_subscriber_categories.php

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -133,3 +133,9 @@
 1.11.7: Improved the frontend components.
 1.11.8: Fixed bug showing the previous and next post.
 1.11.9: Fixed the email sending bug.
+1.12.0:
+    - !!! New configuration was added. If you had no categories enabled or non set, you need to disable newsletter_subscriber_categories
+    - Adding nested categories support and multiple category news.
+    - If no category is set, and newsletter_subscriber_categories is enabled, none of your subscriber will receive any newsletter anymore.
+    - add_nested_categories_support.php
+    - create_posts_categories_table.php


### PR DESCRIPTION
# Changes

## Added nested categories support (nestedTree)  

* Added #115 nested category support
* Removed Sortable Trait and replaced it with NestedTree.
* Added migration to keep previous sorting 

## A news post can have multiple categories.

* Added #129 multiple categories for a news post
* Replaced `category` relation with `categories`.
* Added new pivot table `indikator_news_posts_categories` 
* Replaced `category` field.
* `categories` are now available at sidebar.
* Updated news post list filter


## Im-/Export works with category slugs instead of category title

* removed `category` field
* added `categories` field
* `categories` field now contains a list of category `slug` instead of `title` 

## Changing sending behavior: 
### new option `newsletter_subscriber_categories`

* This option changes the behavior of the email sender to enable sending by subscribed category or disable category filter.
* If `newsletter_subscriber_categories` is enabled, only subscriber with a subscription to a single post categories will receive newsletter.
```
            $categoryIds = $this->news->categories()->lists('id');
            $activeSubscribers->filterCategories($categoryIds);
```
* If `newsletter_subscriber_categories` is disabled, every subscriber will receive any newsletter.
This is useful if you do not use categories at all.

## Additional changes

### #106 prev/next link
Added #106 prev / next link with respected category support
 You can add the `categoryId` to get the next or previous post of that category `$post->next($category->id)`
To get the next post in a `newsPost` component, which respecting the current group, call `newsPost.next` or `newsPost.prev`. 
Both holding `url` and `title` f.e. `newsPost.next.url`
```
{% if __SELF__.prev %}Prev: <a href="{{ __SELF__.prev.url }}" class="prev">{{ __SELF__.prev.title }}</a>{% endif %}
```
if you want the next post, without respecting the group, use `post.next` instead.


# TODO:
- [x] Nested categories
- [x] Migrate categories `sort_order` to nestedTree 
- [x] Multiple categories to posts
- [x] Update Import/Export
- [x] Update sending behavior
- [x] `newsletter_subscriber_categories` translation
- [x] Changing default view of categories component
- [x] Adding nested category posts option in Posts component
- [x] Changing default view of Posts component 
- [x] Changing default view of Post component 
- [x] Drop `category_id` column in posts
- [x] Migrate existing `category` to `categories` entry.

